### PR TITLE
Built modules depend on min.js files

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "bower-install": "bower install",
     "start": "./node_modules/.bin/gulp server",
-    "babel-build": "./node_modules/.bin/babel ./src --out-dir ./lib --ignore *.min.js && ./node_modules/.bin/gulp dist"
+    "babel-build": "./node_modules/.bin/babel ./src --out-dir ./lib && ./node_modules/.bin/gulp dist"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
We can't ignore *.min.js files when modules put in lib depend on them.
